### PR TITLE
php-cs-fixerのホスト名を更新

### DIFF
--- a/infrastructure/php-cs-fixer/Dockerfile
+++ b/infrastructure/php-cs-fixer/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:7.4-fpm-alpine
 
-RUN curl -L http://cs.sensiolabs.org/download/php-cs-fixer-v2.phar -o php-cs-fixer && \
+RUN curl -L https://cs.symfony.com/download/php-cs-fixer-v2.phar -o php-cs-fixer && \
     chmod a+x php-cs-fixer && \
     mv php-cs-fixer /usr/local/bin/php-cs-fixer


### PR DESCRIPTION
こんばんは。大学の友人とプログラミングを学んでいる通りすがりの者です。
`docker-compose build`をする際にphp-cs-fixerのダウンロードサイトのホスト名の変更により名前解決ができず落ちてしまうのでその修正を書いてみました。動作確認済みです。
ホスト名の変更の案内について見つけることができませんでしたが、どうやら https://cs.symfony.com で今は運用されているようです。
友人がよくご覧になっているそうなのでどうぞよろしくお願いします！